### PR TITLE
Update composer.json to use compatible monolog version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php": ">=7.0.0",
         "magento/framework": "^102.0 || ^103.0",
         "magento/module-developer": "^100.3.3",
-        "monolog/monolog": "1.17"
+        "monolog/monolog": "^1.16"
     },
     "require-dev": {
         "magento/magento-coding-standard": "^5.0",


### PR DESCRIPTION
Changed monolog version from "1.17" to "^1.16" to match version used in Magento 2.4