### PR TITLE
chore(deps): ignore Magento plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,9 @@
     ],
     "config": {
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "magento/composer-dependency-version-audit-plugin": false
+        }
     }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/magento2-stdlogging/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
```txt
magento/framework 103.0.5-p1 requires magento/composer-dependency-version-audit-plugin (~0.1) 
```

This plugin is worthless for unit test.

Fixes: N/A

## What is the new behavior?
We don't need to run Magento plugins in our unit tests, so we disable them.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```